### PR TITLE
add optional data_path parameter to generate_spectra_splits

### DIFF
--- a/spectrae/spectra.py
+++ b/spectrae/spectra.py
@@ -178,25 +178,25 @@ class Spectra(ABC):
             if not os.path.exists(f"{name}_spectral_property_graphs"):
                 os.makedirs(f"{name}_spectral_property_graphs")
         else:
-            if not os.path.exists(f"{data_path}/{name}_SPECTRA_splits"):
-                os.makedirs(f"{data_path}/{name}_SPECTRA_splits")
-            if not os.path.exists(f"{data_path}/{name}_spectral_property_graphs"):
-                os.makedirs(f"{data_path}/{name}_spectral_property_graphs")
+            if not os.path.exists(f"{data_path}{name}_SPECTRA_splits"):
+                os.makedirs(f"{data_path}{name}_SPECTRA_splits")
+            if not os.path.exists(f"{data_path}{name}_spectral_property_graphs"):
+                os.makedirs(f"{data_path}{name}_spectral_property_graphs")
 
         splits = []
         for spectral_parameter in spectral_parameters:
             for i in range(number_repeats):
-                if os.path.exists(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}") and not force_reconstruct:
+                if os.path.exists(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}") and not force_reconstruct:
                     print(f"Folder SP_{spectral_parameter}_{i} already exists. Skipping")
-                elif force_reconstruct or not os.path.exists(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
+                elif force_reconstruct or not os.path.exists(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
                     train, test, stats = self.generate_spectra_split(float(spectral_parameter), random_seed[i], test_size)
                     if train is not None:
-                        if not os.path.exists(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
-                            os.makedirs(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}")
+                        if not os.path.exists(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
+                            os.makedirs(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}")
                 
-                        pickle.dump(train, open(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/train.pkl", "wb"))
-                        pickle.dump(test, open(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/test.pkl", "wb"))
-                        pickle.dump(stats, open(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/stats.pkl", "wb"))
+                        pickle.dump(train, open(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/train.pkl", "wb"))
+                        pickle.dump(test, open(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/test.pkl", "wb"))
+                        pickle.dump(stats, open(f"{data_path}{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/stats.pkl", "wb"))
                     else:
                         print(f"Split for SP_{spectral_parameter}_{i} could not be generated since independent set only has one sample")
                 

--- a/spectrae/spectra.py
+++ b/spectrae/spectra.py
@@ -161,7 +161,8 @@ class Spectra(ABC):
                                 number_repeats, 
                                 random_seed, 
                                 test_size = 0.2, 
-                                force_reconstruct = False):
+                                force_reconstruct = False,
+                                data_path = None):
         
         #Random seed is a list of random seeds for each number
         name = self.dataset.name
@@ -170,25 +171,32 @@ class Spectra(ABC):
             if nx.density(self.SPG) >= 0.4:
                 raise Exception("Density of SPG is greater than 0.4, SPECTRA will not work as your dataset is too similar to itself. Please check your dataset and SPECTRA properties.")
 
-        if not os.path.exists(f"{name}_SPECTRA_splits"):
-            os.makedirs(f"{name}_SPECTRA_splits")
-        if not os.path.exists(f"{name}_spectral_property_graphs"):
-            os.makedirs(f"{name}_spectral_property_graphs")
+        if data_path is None:
+            data_path = ""
+            if not os.path.exists(f"{name}_SPECTRA_splits"):
+                os.makedirs(f"{name}_SPECTRA_splits")
+            if not os.path.exists(f"{name}_spectral_property_graphs"):
+                os.makedirs(f"{name}_spectral_property_graphs")
+        else:
+            if not os.path.exists(f"{data_path}/{name}_SPECTRA_splits"):
+                os.makedirs(f"{data_path}/{name}_SPECTRA_splits")
+            if not os.path.exists(f"{data_path}/{name}_spectral_property_graphs"):
+                os.makedirs(f"{data_path}/{name}_spectral_property_graphs")
 
         splits = []
         for spectral_parameter in spectral_parameters:
             for i in range(number_repeats):
-                if os.path.exists(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}") and not force_reconstruct:
+                if os.path.exists(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}") and not force_reconstruct:
                     print(f"Folder SP_{spectral_parameter}_{i} already exists. Skipping")
-                elif force_reconstruct or not os.path.exists(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
+                elif force_reconstruct or not os.path.exists(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
                     train, test, stats = self.generate_spectra_split(float(spectral_parameter), random_seed[i], test_size)
                     if train is not None:
-                        if not os.path.exists(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
-                            os.makedirs(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}")
+                        if not os.path.exists(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}"):
+                            os.makedirs(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}")
                 
-                        pickle.dump(train, open(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/train.pkl", "wb"))
-                        pickle.dump(test, open(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/test.pkl", "wb"))
-                        pickle.dump(stats, open(f"{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/stats.pkl", "wb"))
+                        pickle.dump(train, open(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/train.pkl", "wb"))
+                        pickle.dump(test, open(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/test.pkl", "wb"))
+                        pickle.dump(stats, open(f"{data_path}/{name}_SPECTRA_splits/SP_{spectral_parameter}_{i}/stats.pkl", "wb"))
                     else:
                         print(f"Split for SP_{spectral_parameter}_{i} could not be generated since independent set only has one sample")
                 


### PR DESCRIPTION
added an optional data_path parameter that can be used to specify path where the spectra splits can be saved to. If left empty, the folder gets put in the root directory, as it was before. Beware: when specifying location, make sure to format the path as `<path/to/folder/>`, with a final `/`. This is necessary to preserve the original implementation where the folders get written to the root folder without adding to much additional logic. 